### PR TITLE
Force HTTPS

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -34,7 +34,10 @@ module.exports = function (grunt) {
       }
     },
     jshint: {
-      files: ['Gruntfile.js', 'src/**/*.js', 'test/**/*.js']
+      files: ['Gruntfile.js', 'src/**/*.js', 'test/**/*.js'],
+      options: {
+        reporterOutput: ''
+      }
     },
     jscs: {
       options: {

--- a/src/showdown-youtube.js
+++ b/src/showdown-youtube.js
@@ -94,9 +94,9 @@
             var d = parseDimensions(rest),
               m, fUrl = '';
             if ((m = shortYoutubeRegex.exec(url)) || (m = fullYoutubeRegex.exec(url))) {
-              fUrl = '//www.youtube.com/embed/' + m[1] + '?rel=0';
+              fUrl = 'https://www.youtube.com/embed/' + m[1] + '?rel=0';
             } else if ((m = vimeoRegex.exec(url))) {
-              fUrl = '//player.vimeo.com/video/' + m[1];
+              fUrl = 'https://player.vimeo.com/video/' + m[1];
             } else {
               return match;
             }

--- a/test/cases/inline_style_with_full_links.html
+++ b/test/cases/inline_style_with_full_links.html
@@ -1,3 +1,3 @@
-<iframe src="//www.youtube.com/embed/dQw4w9WgXcQ?rel=0" width="420px" height="315px" frameborder="0" allowfullscreen></iframe>
+<iframe src="https://www.youtube.com/embed/dQw4w9WgXcQ?rel=0" width="420px" height="315px" frameborder="0" allowfullscreen></iframe>
 
-<iframe src="//player.vimeo.com/video/110845548" width="420px" height="315px" frameborder="0" allowfullscreen></iframe>
+<iframe src="https://player.vimeo.com/video/110845548" width="420px" height="315px" frameborder="0" allowfullscreen></iframe>

--- a/test/cases/inline_style_with_short_links.html
+++ b/test/cases/inline_style_with_short_links.html
@@ -1,1 +1,1 @@
-<iframe src="//www.youtube.com/embed/dQw4w9WgXcQ?rel=0" width="420px" height="315px" frameborder="0" allowfullscreen></iframe>
+<iframe src="https://www.youtube.com/embed/dQw4w9WgXcQ?rel=0" width="420px" height="315px" frameborder="0" allowfullscreen></iframe>

--- a/test/cases/reference_style_with_full_links.html
+++ b/test/cases/reference_style_with_full_links.html
@@ -1,3 +1,3 @@
-<iframe src="//www.youtube.com/embed/dQw4w9WgXcQ?rel=0" width="420px" height="315px" frameborder="0" allowfullscreen></iframe>
+<iframe src="https://www.youtube.com/embed/dQw4w9WgXcQ?rel=0" width="420px" height="315px" frameborder="0" allowfullscreen></iframe>
 
-<iframe src="//player.vimeo.com/video/110845548" width="420px" height="315px" frameborder="0" allowfullscreen></iframe>
+<iframe src="https://player.vimeo.com/video/110845548" width="420px" height="315px" frameborder="0" allowfullscreen></iframe>

--- a/test/cases/reference_style_with_short_links.html
+++ b/test/cases/reference_style_with_short_links.html
@@ -1,1 +1,1 @@
-<iframe src="//www.youtube.com/embed/dQw4w9WgXcQ?rel=0" width="420px" height="315px" frameborder="0" allowfullscreen></iframe>
+<iframe src="https://www.youtube.com/embed/dQw4w9WgXcQ?rel=0" width="420px" height="315px" frameborder="0" allowfullscreen></iframe>


### PR DESCRIPTION
The extension currently forces URLs to have a double slash.  This pull request forces HTTPS instead of a double slash.

There are two main issues with the double slash approach:

* Double slash is considered an anti-pattern that reduces internet security (https://www.paulirish.com/2010/the-protocol-relative-url/ - Google Chrome dev team)
* It breaks applications not running on a http/https protocol - for example electron apps or cordova apps.