### PR TITLE
Fix repository links in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
   "license": "BSD-2-Clause",
   "repository": {
     "type": "git",
-    "url": "https://github.com/showdownjs/youtbe-extension.git",
-    "web": "https://github.com/showdownjs/youtbe-extension"
+    "url": "https://github.com/showdownjs/youtube-extension.git",
+    "web": "https://github.com/showdownjs/youtube-extension"
   },
   "bugs": {
     "url": "https://github.com/showdownjs/youtube-extension/issues"


### PR DESCRIPTION
On npm the link to the GitHub repository is broken. This change fixes the link.